### PR TITLE
Support Device Update

### DIFF
--- a/cmd/device/device.go
+++ b/cmd/device/device.go
@@ -15,10 +15,11 @@
 package device
 
 import (
-	adddevice "github.com/edgexfoundry-holding/edgex-cli/cmd/device/add"
-	listdevice "github.com/edgexfoundry-holding/edgex-cli/cmd/device/list"
-	rmdevice "github.com/edgexfoundry-holding/edgex-cli/cmd/device/rm"
-
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/device/add"
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/device/list"
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/device/rm"
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/device/update"
+	
 	"github.com/spf13/cobra"
 )
 
@@ -29,8 +30,9 @@ func NewCommand() *cobra.Command {
 		Short: "Device command",
 		Long:  `Actions related to devices.`,
 	}
-	cmd.AddCommand(rmdevice.NewCommand())
-	cmd.AddCommand(listdevice.NewCommand())
-	cmd.AddCommand(adddevice.NewCommand())
+	cmd.AddCommand(rm.NewCommand())
+	cmd.AddCommand(list.NewCommand())
+	cmd.AddCommand(add.NewCommand())
+	cmd.AddCommand(update.NewCommand())
 	return cmd
 }

--- a/cmd/device/list/list.go
+++ b/cmd/device/list/list.go
@@ -28,9 +28,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const deviceTempl = "Device ID\tDevice Name\tOperating State\tAdmin State\tDevice Service\tDevice Profile\n" +
+const deviceTempl = "Device ID\tDevice Name\tDescription\tOperating State\tAdmin State\tDevice Service\tDevice Profile\n" +
 	"{{range .}}" +
-	"{{.Id}}\t{{.Name}}\t{{.OperatingState}}\t{{.AdminState}}\t{{.Service.Name}}\t{{.Profile.Name}}\n" +
+	"{{.Id}}\t{{.Name}}\t{{.Description}}\t{{.OperatingState}}\t{{.AdminState}}\t{{.Service.Name}}\t{{.Profile.Name}}\n" +
 	"{{end}}"
 
 var name string

--- a/cmd/device/update/update.go
+++ b/cmd/device/update/update.go
@@ -50,12 +50,12 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update device",
-		Long: `Update device with given name using interactive mode or update device(s) described in a JSON file.
-Interactive mode opens a default editor to customize Device information`,
+		Long: `Update device(s) described in the given JSON file or use the interactive mode enabled by providing 
+ name of existing device service`,
 		RunE: deviceHandler,
 	}
-	cmd.Flags().StringVarP(&name, "name", "n", "", "Name")
-	cmd.Flags().StringVarP(&file, "file", "f", "", "Json file containing device service configuration to update")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Device name. Device with given name is loaded into default editor, ready to be customized")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Json file containing device configuration to update")
 	return cmd
 }
 
@@ -125,7 +125,7 @@ func parseDevice(name string) (models.Device, error) {
 	var d models.Device
 	err = json.Unmarshal(updatedDeviceBytes, &d)
 	if err != nil {
-		return models.Device{}, errors.New("Unable to execute the command. The provided information is not valid: " + err.Error())
+		return models.Device{}, errors.New("Unable to execute the command. The provided information is invalid: " + err.Error())
 	}
 	return d, nil
 }

--- a/cmd/device/update/update.go
+++ b/cmd/device/update/update.go
@@ -1,0 +1,162 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+
+	"github.com/edgexfoundry-holding/edgex-cli/config"
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/editor"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/spf13/cobra"
+)
+
+const deviceTemp = `{
+  "Id": "{{.Id}}",
+  "Name": "{{.Name}}",
+  "Description":"{{.Description}}",
+  "Adminstate":"{{.AdminState}}",
+  "OperatingState": "{{.OperatingState}}",
+  "Protocols":{ 
+     {{- $length := len .Protocols }}{{$idx:=0}}
+     {{- range $k,$ProtocolProperties := .Protocols}}
+     "{{$k}}":{ 
+	    {{- $innerLength := len $ProtocolProperties }}{{$innerIdx:=0}} 
+        {{- range $ki,$vi := $ProtocolProperties}}
+          "{{- $ki}}":"{{$vi}}"{{if not (lastElem $innerIdx $innerLength)}},{{end}}{{$innerIdx =  inc $innerIdx}}
+        {{end}}} {{if not (lastElem $idx $length)}},{{end}}{{$idx =  inc $idx}} 
+     {{end}}}, 
+  "Service": {
+     "Name": "{{.Service.Name}}"
+  },
+  "Profile": {
+    "Name": "{{.Profile.Name}}"
+  }
+}`
+
+var name string
+var file string
+
+// NewCommand returns the update device command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update device",
+		Long: `Update device with given name using interactive mode or update device(s) described in a JSON file.
+Interactive mode opens a default editor to customize Device information`,
+		RunE: deviceHandler,
+	}
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Name")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Json file containing device service configuration to update")
+	return cmd
+}
+
+func deviceHandler(cmd *cobra.Command, args []string) error {
+	if name != "" && file != "" {
+		return errors.New("you could work with interactive mode by providing the name of the device you want to update or by providing a file, but not with both")
+	}
+
+	if name == "" && file == "" {
+		return errors.New("Please, provide file or device name ")
+	}
+
+	if file != "" {
+		return updateDevicesFromFile()
+	}
+	//Update the device provided by name using interactive mode to alter it
+	d, err := parseDevice(name)
+	if err != nil {
+		return err
+	}
+
+	client := local.New(config.Conf.Clients["Metadata"].Url() + clients.ApiDeviceRoute)
+	err = metadata.NewDeviceClient(client).Update(context.Background(), d)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func updateDevicesFromFile() error {
+	devices, err := LoadDevicesFromFile(file)
+	if err != nil {
+		return err
+	}
+
+	client := local.New(config.Conf.Clients["Metadata"].Url() + clients.ApiDeviceRoute)
+	for _, d := range devices {
+		err = metadata.NewDeviceClient(client).Update(context.Background(), d)
+		if err != nil {
+			fmt.Println("Error: ", err.Error())
+		}
+	}
+	return nil
+}
+
+//loads a device service to be updated and open a default editor for customization
+func parseDevice(name string) (models.Device, error) {
+	//load Device from database
+	client := local.New(config.Conf.Clients["Metadata"].Url() + clients.ApiDeviceRoute)
+	device, err := metadata.NewDeviceClient(client).DeviceForName(context.Background(), name)
+	if err != nil {
+		return models.Device{}, err
+	}
+
+	//populate the template with the loaded device and open default editor, so the client could customize the data
+	updatedDeviceBytes, err := editor.OpenInteractiveEditor(device, deviceTemp, template.FuncMap{
+		"inc": func(i int) int {
+			return i + 1
+		},
+		"lastElem": editor.IsLastElementOfSlice,
+	})
+	if err != nil {
+		return models.Device{}, err
+	}
+
+	var d models.Device
+	err = json.Unmarshal(updatedDeviceBytes, &d)
+	if err != nil {
+		return models.Device{}, errors.New("Unable to execute the command. The provided information is not valid: " + err.Error())
+	}
+	return d, nil
+}
+
+
+//LoadDevicesFromFile could read a file that contains single Device or list of Device
+func LoadDevicesFromFile(filePath string) ([]models.Device, error){
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Error: Invalid Json")
+		}
+	}()
+	file, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var devices []models.Device
+
+	//check if the file contains just one Device
+	var d models.Device
+	err = json.Unmarshal(file, &d)
+	if err != nil {
+		//check if the file contains list of Device
+		err = json.Unmarshal(file, &devices)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		devices = append(devices, d)
+	}
+	return devices, nil
+}
+

--- a/cmd/deviceservice/deviceservice.go
+++ b/cmd/deviceservice/deviceservice.go
@@ -15,10 +15,10 @@
 package deviceservice
 
 import (
-	adddeviceservice "github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/add"
-	listdeviceservice "github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/list"
-	rmdeviceservice "github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/rm"
-	updatedeviceservice "github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/update"
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/add"
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/list"
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/rm"
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/update"
 
 	"github.com/spf13/cobra"
 )
@@ -49,9 +49,9 @@ The DS Layer converts the data produced and communicated by the IoT object, into
 common EdgeX Foundry data structure, and sends that converted data into the Core Services 
 layer, and to other microservices in other layers of EdgeX Foundry.`,
 	}
-	cmd.AddCommand(rmdeviceservice.NewCommand())
-	cmd.AddCommand(listdeviceservice.NewCommand())
-	cmd.AddCommand(adddeviceservice.NewCommand())
-	cmd.AddCommand(updatedeviceservice.NewCommand())
+	cmd.AddCommand(rm.NewCommand())
+	cmd.AddCommand(list.NewCommand())
+	cmd.AddCommand(add.NewCommand())
+	cmd.AddCommand(update.NewCommand())
 	return cmd
 }

--- a/cmd/deviceservice/update/update.go
+++ b/cmd/deviceservice/update/update.go
@@ -46,7 +46,7 @@ func NewCommand() *cobra.Command {
 		Use:   "update",
 		Short: "Update device service",
 		Long:  `Update device service(s) described in the given JSON file or use the interactive mode enabled by providing 
- name of existing device service.`,
+ name of existing device service`,
 		RunE:  deviceServiceHandler,
 	}
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Device Service name. Service with given name is loaded into default editor, ready to be customized")
@@ -99,7 +99,7 @@ func parseDeviceService(name string) (models.DeviceService, error) {
 	var updatedDeviceService models.DeviceService
 	err = json.Unmarshal(updatedDeviceServiceBytes, &updatedDeviceService)
 	if err != nil {
-		return models.DeviceService{}, errors.New("Unable to execute the command. The provided information is not valid: " + err.Error())
+		return models.DeviceService{}, errors.New("Unable to execute the command. The provided information is invalid: " + err.Error())
 	}
 	return updatedDeviceService, err
 }


### PR DESCRIPTION
Device update could be updated in two ways ./edgex-cli device update :
- by file that contains one or multiple devices (using -f flag)
- by name. CLI load the device with given name and populates the interactive template,
ready to be modified by the client (--name flag)

Issue:  https://github.com/edgexfoundry/edgex-cli/issues/245
Depends on PR: https://github.com/edgexfoundry/edgex-cli/pull/271

Signed-off-by: Diana Atanasova <dianaa@vmware.com>