### PR TITLE
Remove left overs imports that still contains "edgex-holding/cli"

### DIFF
--- a/cmd/device/device.go
+++ b/cmd/device/device.go
@@ -16,10 +16,10 @@ package device
 
 import (
 
-	"github.com/edgexfoundry-holding/edgex-cli/cmd/device/add"
-	"github.com/edgexfoundry-holding/edgex-cli/cmd/device/list"
-	"github.com/edgexfoundry-holding/edgex-cli/cmd/device/rm"
-	"github.com/edgexfoundry-holding/edgex-cli/cmd/device/update"
+	"github.com/edgexfoundry/edgex-cli/cmd/device/add"
+	"github.com/edgexfoundry/edgex-cli/cmd/device/list"
+	"github.com/edgexfoundry/edgex-cli/cmd/device/rm"
+	"github.com/edgexfoundry/edgex-cli/cmd/device/update"
 	
 	"github.com/spf13/cobra"
 )

--- a/cmd/device/update/update.go
+++ b/cmd/device/update/update.go
@@ -8,8 +8,8 @@ import (
 	"html/template"
 	"io/ioutil"
 
-	"github.com/edgexfoundry-holding/edgex-cli/config"
-	"github.com/edgexfoundry-holding/edgex-cli/pkg/editor"
+	"github.com/edgexfoundry/edgex-cli/config"
+	"github.com/edgexfoundry/edgex-cli/pkg/editor"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"

--- a/cmd/deviceservice/deviceservice.go
+++ b/cmd/deviceservice/deviceservice.go
@@ -16,10 +16,10 @@ package deviceservice
 
 import (
 
-	"github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/add"
-	"github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/list"
-	"github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/rm"
-	"github.com/edgexfoundry-holding/edgex-cli/cmd/deviceservice/update"
+	"github.com/edgexfoundry/edgex-cli/cmd/deviceservice/add"
+	"github.com/edgexfoundry/edgex-cli/cmd/deviceservice/list"
+	"github.com/edgexfoundry/edgex-cli/cmd/deviceservice/rm"
+	"github.com/edgexfoundry/edgex-cli/cmd/deviceservice/update"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/interval/add/add.go
+++ b/cmd/interval/add/add.go
@@ -19,16 +19,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/edgexfoundry-holding/edgex-cli/pkg/editor"
+	"github.com/edgexfoundry/edgex-cli/pkg/editor"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/scheduler"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
 	"io/ioutil"
 
-
 	"github.com/edgexfoundry/edgex-cli/config"
-	request "github.com/edgexfoundry/edgex-cli/pkg"
-
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 


### PR DESCRIPTION
Fix: https://github.com/edgexfoundry/edgex-cli/issues/285

Signed-off-by: Diana Atanasova <dianaa@vmware.com>