### PR TITLE
refactor:create device:Create Device use json type and interactive mode

### DIFF
--- a/cmd/device/update/update.go
+++ b/cmd/device/update/update.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const deviceTemp = `{
+const DeviceTemp = `{
   "Id": "{{.Id}}",
   "Name": "{{.Name}}",
   "Description":"{{.Description}}",
@@ -112,7 +112,7 @@ func parseDevice(name string) (models.Device, error) {
 	}
 
 	//populate the template with the loaded device and open default editor, so the client could customize the data
-	updatedDeviceBytes, err := editor.OpenInteractiveEditor(device, deviceTemp, template.FuncMap{
+	updatedDeviceBytes, err := editor.OpenInteractiveEditor(device, DeviceTemp, template.FuncMap{
 		"inc": func(i int) int {
 			return i + 1
 		},

--- a/cmd/event/add/add.go
+++ b/cmd/event/add/add.go
@@ -87,7 +87,6 @@ func NewCommand() *cobra.Command {
 			populateEvent(&newEvent)
 			var newEventBytes []byte
 			var err error
-			interactiveMode, err := command.Flags().GetBool(editor.InteractiveModeLabel)
 			if interactiveMode {
 				newEventBytes, err = openInteractiveEditor(newEvent)
 			} else {


### PR DESCRIPTION
Create device use Json instead of TOLM.
 Device create could be updated in two ways ./edgex-cli device create :
    
    - by file that contains one or multiple devices (using -f flag)
    - by name - CLI load the device with given name and populates the interactive template,
    ready to be modified (using --name flag)
    
    Issue: https://github.com/edgexfoundry/edgex-cli/issues/272
