### PR TITLE
feat: update device admin state

### DIFF
--- a/cmd/device/adminstate/adminstatus.go
+++ b/cmd/device/adminstate/adminstatus.go
@@ -1,0 +1,17 @@
+package adminstate
+
+import (
+	"github.com/edgexfoundry/edgex-cli/cmd/device/adminstate/update"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns device adminstate
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "adminstate",
+		Short: "Device admin state ",
+	}
+	cmd.AddCommand(update.NewCommand())
+	return cmd
+}

--- a/cmd/device/adminstate/update/update.go
+++ b/cmd/device/adminstate/update/update.go
@@ -1,0 +1,68 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/edgexfoundry/edgex-cli/config"
+	"github.com/spf13/cobra"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/requests/states/admin"
+)
+
+var deviceName string
+var deviceId string
+var state string
+
+// NewCommand returns the update deviceName command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update deviceName admin state",
+		Long:  `Update deviceName admin state`,
+		RunE:  updateAdminStatusHandler,
+	}
+	cmd.Flags().StringVarP(&state, "state", "s", "", fmt.Sprintf("Admin State \nValues: [%s]", strings.Join([]string{models.Locked, models.Unlocked}, ",")))
+	cmd.Flags().StringVarP(&deviceName, "name", "n", "", "Name of the deviceName to be updated")
+	cmd.Flags().StringVarP(&deviceId, "id", "i", "", "Id of the deviceName to be updated")
+	return cmd
+}
+
+func updateAdminStatusHandler(cmd *cobra.Command, args []string) error {
+	state = strings.ToUpper(state)
+	if err := validate(); err != nil {
+		return err
+	}
+	url := config.Conf.Clients["Metadata"].Url() + clients.ApiDeviceRoute
+	mdc := metadata.NewDeviceClient(
+		local.New(url),
+	)
+	var err error
+	if deviceName != "" {
+		err = mdc.UpdateAdminStateByName(context.Background(), deviceName, admin.UpdateRequest{AdminState: models.AdminState(state)})
+	} else {
+		err = mdc.UpdateAdminState(context.Background(), deviceId, admin.UpdateRequest{AdminState: models.AdminState(state)})
+	}
+	return err
+}
+
+func validate() error {
+	if state == "" {
+		return errors.New("admin state should be specified")
+	} else if state != "" {
+		valid, err := models.AdminState(state).Validate()
+		if !valid {
+			return err
+		}
+	} else if deviceName == "" && deviceId == "" {
+		return errors.New("deviceName or deviceId should be specified")
+	} else if deviceName != "" && deviceId != "" {
+		return errors.New("only one deviceName or deviceId should be specified")
+	}
+	return nil
+}

--- a/cmd/device/device.go
+++ b/cmd/device/device.go
@@ -16,6 +16,7 @@ package device
 
 import (
 	"github.com/edgexfoundry/edgex-cli/cmd/device/add"
+	"github.com/edgexfoundry/edgex-cli/cmd/device/adminstate"
 	"github.com/edgexfoundry/edgex-cli/cmd/device/list"
 	"github.com/edgexfoundry/edgex-cli/cmd/device/rm"
 	"github.com/edgexfoundry/edgex-cli/cmd/device/update"
@@ -34,5 +35,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(list.NewCommand())
 	cmd.AddCommand(add.NewCommand())
 	cmd.AddCommand(update.NewCommand())
+	cmd.AddCommand(adminstate.NewCommand())
+	//cmd.AddCommand(operstate.NewCommand())
 	return cmd
 }


### PR DESCRIPTION
Enable update of device admin state by deviceName or deviceId
Usage Examples:
./edgex-cli device adminstate update  -s LOCKED -d TestRandom-Integer-Device
./edgex-cli device adminstate update  -s unlocked --deviceId 089d3bbf-3795-4ac6-b471-e9645969f720

Closes: https://github.com/edgexfoundry/edgex-cli/issues/247

Signed-off-by: Diana Atanasova <dianaa@vmware.com>