### PR TITLE
feat: add support of multiple objects delete by id

### DIFF
--- a/cmd/device/rm/rm.go
+++ b/cmd/device/rm/rm.go
@@ -18,11 +18,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 
 	"github.com/edgexfoundry/edgex-cli/config"
+	request "github.com/edgexfoundry/edgex-cli/pkg"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+
 	"github.com/spf13/cobra"
 )
 
@@ -52,12 +55,10 @@ You can use: '$ edgex device list' to find a device's name and ID.`,
 				return err
 			}
 
-			deviceID := args[0]
-			err = mdc.Delete(ctx, deviceID)
-			if err == nil {
-				fmt.Printf("Removed: %s\n", deviceID)
+			if len(args[0]) != 0 {
+				return request.DeleteByIds(mdc, args)
 			}
-			return err
+			return nil
 		},
 	}
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Delete Device by name")

--- a/cmd/interval/rm/rm.go
+++ b/cmd/interval/rm/rm.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/edgex-cli/config"
+	request "github.com/edgexfoundry/edgex-cli/pkg"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/scheduler"
@@ -42,14 +43,13 @@ func removeIntervalHandler(cmd *cobra.Command, args []string) (err error) {
 	if name != "" {
 		deletedBy = name
 		err = sc.DeleteByName(context.Background(), name)
-	} else {
-		deletedBy = args[0]
-		err = sc.Delete(context.Background(), deletedBy)
+		if err != nil {
+			return
+		}
+		fmt.Printf("Removed: %s\n", deletedBy)
+	} else if len(args[0]) != 0 {
+		return request.DeleteByIds(sc, args)
 	}
-	if err != nil {
-		return
-	}
-	fmt.Printf("Removed: %s\n", deletedBy)
 	return nil
 }
 

--- a/cmd/profile/rm/rm.go
+++ b/cmd/profile/rm/rm.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/edgex-cli/config"
+	request "github.com/edgexfoundry/edgex-cli/pkg"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
@@ -51,15 +52,10 @@ func NewCommand() *cobra.Command {
 					fmt.Printf("Removed: %s\n", name)
 				}
 				return
+			} else if len(args) != 0 {
+				return request.DeleteByIds(mdc, args)
 			}
-
-			deviceID := args[0]
-			err = mdc.Delete(ctx, deviceID)
-			if err == nil {
-				fmt.Printf("Removed: %s\n", deviceID)
-				return
-			}
-			return
+			return nil
 		},
 	}
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Delete device profile by name")

--- a/pkg/request.go
+++ b/pkg/request.go
@@ -76,7 +76,7 @@ func DeleteByIds(i interface{}, ids []string) error {
 	} else if methodVal.Type().In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
 		return fmt.Errorf("client method's first input parameter is %q, want `context.Context`", methodVal.Type().In(0))
 	} else if methodVal.Type().In(1) != reflect.TypeOf((*string)(nil)).Elem() {
-		return fmt.Errorf("client method's first input parameter is %q, want `context.Context`", methodVal.Type().In(1))
+		return fmt.Errorf("client method's first input parameter is %q, want `string`", methodVal.Type().In(1))
 	} else if methodVal.Type().NumOut() != 1 {
 		return fmt.Errorf("client method has %q output parameters, want 1", methodVal.Type().NumOut())
 	}

--- a/pkg/request.go
+++ b/pkg/request.go
@@ -66,3 +66,29 @@ func getType(item interface{}) string {
 		return t.Name()
 	}
 }
+
+func DeleteByIds(i interface{}, ids []string) error {
+	methodVal := reflect.ValueOf(i).MethodByName("Delete")
+	if !methodVal.IsValid() {
+		return fmt.Errorf("unsupported method: %s", "Delete")
+	} else if methodVal.Type().NumIn() != 2 {
+		return fmt.Errorf("client method has %q input parameters, want 2", methodVal.Type().NumIn())
+	} else if methodVal.Type().In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
+		return fmt.Errorf("client method's first input parameter is %q, want `context.Context`", methodVal.Type().In(0))
+	} else if methodVal.Type().In(1) != reflect.TypeOf((*string)(nil)).Elem() {
+		return fmt.Errorf("client method's first input parameter is %q, want `context.Context`", methodVal.Type().In(1))
+	} else if methodVal.Type().NumOut() != 1 {
+		return fmt.Errorf("client method has %q output parameters, want 1", methodVal.Type().NumOut())
+	}
+
+	for _, id := range ids {
+		out := methodVal.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(id)})
+		err := out[0]
+		if !err.IsNil() {
+			fmt.Printf("Error: %s", err.Interface().(error))
+		} else {
+			fmt.Printf("Removed: %s \n", id)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Make Device, Interval and Profile able to delete
multiple objects at once by providing list of Ids
Example:
./edgex-cli device rm [id1] [id2] [id3]

Signed-off-by: Diana Atanasova <dianaa@vmware.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
https://github.com/edgexfoundry/edgex-cli/issues/304

## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information