### PR TITLE
feat: Add device oper status update command

### DIFF
--- a/cmd/device/device.go
+++ b/cmd/device/device.go
@@ -18,6 +18,7 @@ import (
 	"github.com/edgexfoundry/edgex-cli/cmd/device/add"
 	"github.com/edgexfoundry/edgex-cli/cmd/device/adminstate"
 	"github.com/edgexfoundry/edgex-cli/cmd/device/list"
+	"github.com/edgexfoundry/edgex-cli/cmd/device/operstatus"
 	"github.com/edgexfoundry/edgex-cli/cmd/device/rm"
 	"github.com/edgexfoundry/edgex-cli/cmd/device/update"
 
@@ -36,6 +37,6 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(add.NewCommand())
 	cmd.AddCommand(update.NewCommand())
 	cmd.AddCommand(adminstate.NewCommand())
-	//cmd.AddCommand(operstate.NewCommand())
+	cmd.AddCommand(operstatus.NewCommand())
 	return cmd
 }

--- a/cmd/device/operstatus/operstatus.go
+++ b/cmd/device/operstatus/operstatus.go
@@ -1,0 +1,70 @@
+package operstatus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/edgexfoundry/edgex-cli/config"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/requests/states/operating"
+
+	"github.com/spf13/cobra"
+)
+
+var deviceName string
+var deviceId string
+var state string
+
+// NewCommand returns device operstatus
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "operstate",
+		Short: "Update deviceName operating state",
+		Long:  `Update deviceName operating state`,
+		RunE:  updateOperStatusHandler,
+	}
+	cmd.Flags().StringVarP(&state, "state", "s", "", fmt.Sprintf("Operating State \nValues: [%s]", strings.Join([]string{models.Disabled, models.Enabled}, ",")))
+	cmd.Flags().StringVarP(&deviceName, "name", "n", "", "Name of the deviceName to be updated")
+	cmd.Flags().StringVarP(&deviceId, "id", "i", "", "Id of the deviceName to be updated")
+	return cmd
+}
+
+func updateOperStatusHandler(cmd *cobra.Command, args []string) error {
+	state = strings.ToUpper(state)
+	if err := validate(); err != nil {
+		return err
+	}
+	url := config.Conf.Clients["Metadata"].Url() + clients.ApiDeviceRoute
+	mdc := metadata.NewDeviceClient(
+		local.New(url),
+	)
+	var err error
+	if deviceName != "" {
+		err = mdc.UpdateOpStateByName(context.Background(), deviceName, operating.UpdateRequest{OperatingState: models.OperatingState(state)})
+	} else {
+		err = mdc.UpdateOpState(context.Background(), deviceId, operating.UpdateRequest{OperatingState: models.OperatingState(state)})
+	}
+	return err
+}
+
+func validate() error {
+	if state == "" {
+		return errors.New("operating state should be specified")
+	} else if state != "" {
+		valid, err := models.OperatingState(state).Validate()
+		if !valid {
+			return err
+		}
+	} else if deviceName == "" && deviceId == "" {
+		return errors.New("deviceName or deviceId should be specified")
+	} else if deviceName != "" && deviceId != "" {
+		return errors.New("only one deviceName or deviceId should be specified")
+	}
+	return nil
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
(Docs will be update in separate PR)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
https://github.com/edgexfoundry/edgex-cli/issues/296

## What is the new behavior?
New command for update device operating state is added. Examples: 
./edgex-cli device operstate -n <device_name> -s <OperState>
./edgex-clidevice operstate -i <device_ID> -s <OperState

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## New Imports
No

## Specific Instructions
No


## Other information