### PR TITLE
fix: PR Template point to correct file for conventional commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please check if your PR fulfills the following requirements:
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.
+**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/master/.github/Contributing.md.
 
 ## What is the current behavior?
 <!-- Please describe the current behavior and link to a relevant issue. -->


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
As you see one line above there is a link for conventional commits . This link cannot be found. This PR change the PR Template to point to correct internal for edgex-cli repository Contributing.md file : https://github.com/edgexfoundry/edgex-cli/blob/master/.github/Contributing.md


## Issue Number:
https://github.com/edgexfoundry/edgex-cli/issues/314

## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
No


## Other information