### PR TITLE
feat: Add attribution and Lisence files in archive files

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -16,7 +16,7 @@
 ARG BASE=golang:1.15-alpine
 FROM ${BASE}
 
-ARG ALPINE_PKG_BASE="make git zip"
+ARG ALPINE_PKG_BASE="make git zip tar"
 ARG ALPINE_PKG_EXTRA=""
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ build-all:
 	GOOS=darwin GOARCH=amd64 $(GO) build -o ${ARTIFACT_ROOT}/$(BINARY)-mac $(GOFLAGS)
 	GOOS=windows GOARCH=amd64 $(GO) build -o ${ARTIFACT_ROOT}/$(BINARY)-win.exe $(GOFLAGS)
 
-	tar -czvf ${ARTIFACT_ROOT}/$(BINARY)-linux-amd64-$(VERSION).tar.gz -C ${ARTIFACT_ROOT} $(BINARY)-linux-amd64
-	tar -czvf ${ARTIFACT_ROOT}/$(BINARY)-linux-arm64-$(VERSION).tar.gz -C ${ARTIFACT_ROOT} $(BINARY)-linux-arm64
-	tar -czvf ${ARTIFACT_ROOT}/$(BINARY)-mac-$(VERSION).tar.gz -C ${ARTIFACT_ROOT} $(BINARY)-mac
-	zip -j ${ARTIFACT_ROOT}/$(BINARY)-win-$(VERSION).zip ${ARTIFACT_ROOT}/$(BINARY)-win.exe
+	tar -czvf ${ARTIFACT_ROOT}/$(BINARY)-linux-amd64-$(VERSION).tar.gz Attribution.txt LICENSE -C ${ARTIFACT_ROOT} $(BINARY)-linux-amd64
+	tar -czvf ${ARTIFACT_ROOT}/$(BINARY)-linux-arm64-$(VERSION).tar.gz Attribution.txt LICENSE -C ${ARTIFACT_ROOT} $(BINARY)-linux-arm64
+	tar -czvf ${ARTIFACT_ROOT}/$(BINARY)-mac-$(VERSION).tar.gz Attribution.txt LICENSE -C ${ARTIFACT_ROOT} $(BINARY)-mac
+	zip -j ${ARTIFACT_ROOT}/$(BINARY)-win-$(VERSION).zip ${ARTIFACT_ROOT}/$(BINARY)-win.exe Attribution.txt LICENSE
 
 
 test:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Archie file contains only the executable

## Issue Number:
https://github.com/edgexfoundry/edgex-cli/issues/324

## What is the new behavior?
Add Attribution.txt and LICENSE files in all archive files next to the CLI executable.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information