### PR TITLE
feat: issue get/put commands

### DIFF
--- a/cmd/command/command.go
+++ b/cmd/command/command.go
@@ -14,7 +14,10 @@
 package command
 
 import (
-	listcommand "github.com/edgexfoundry/edgex-cli/cmd/command/list"
+	"github.com/edgexfoundry/edgex-cli/cmd/command/exec/get"
+	"github.com/edgexfoundry/edgex-cli/cmd/command/exec/put"
+	"github.com/edgexfoundry/edgex-cli/cmd/command/list"
+
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +28,8 @@ func NewCommand() *cobra.Command {
 		Short: "`Command` command",
 		Long:  `Actions related to commands.`,
 	}
-	cmd.AddCommand(listcommand.NewCommand())
+	cmd.AddCommand(list.NewCommand())
+	cmd.AddCommand(get.NewCommand())
+	cmd.AddCommand(put.NewCommand())
 	return cmd
 }

--- a/cmd/command/exec/get/get.go
+++ b/cmd/command/exec/get/get.go
@@ -1,0 +1,41 @@
+package get
+
+import (
+	"context"
+	"fmt"
+	"github.com/edgexfoundry/edgex-cli/config"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/command"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+
+	"github.com/spf13/cobra"
+)
+
+var deviceName string
+var cmdName string
+var data string
+
+// NewCommand returns `issue Get command` command
+func NewCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "get",
+		Short: "Issue GET command",
+		Long:  `Issue GET command referenced by the command name to the device also referenced by name`,
+		RunE:  handler,
+	}
+	cmd.Flags().StringVarP(&deviceName, "device", "d", "", "Specify the name of device")
+	cmd.Flags().StringVarP(&cmdName, "cmd", "n", "", "Specify the name of the command to be executed")
+	cmd.MarkFlagRequired("device")
+	cmd.MarkFlagRequired("cmd")
+	return cmd
+}
+
+func handler(cmd *cobra.Command, args []string) error {
+	client := local.New(config.Conf.Clients["Command"].Url() + clients.ApiDeviceRoute)
+	res, err := command.NewCommandClient(client).GetDeviceCommandByNames(context.Background(), deviceName, cmdName)
+	if err == nil {
+		fmt.Printf("%s\n", res)
+	}
+	return err
+}

--- a/cmd/command/exec/put/put.go
+++ b/cmd/command/exec/put/put.go
@@ -1,0 +1,58 @@
+package put
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/edgexfoundry/edgex-cli/config"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/command"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+
+	"github.com/spf13/cobra"
+)
+
+var device string
+var cmdName string
+var body string
+var file string
+
+// NewCommand returns `issue Put command` command
+func NewCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "put",
+		Short: "Issue PUT command",
+		Long:  `Issue PUT command referenced by the command name to the device also referenced by name`,
+		RunE:  handler,
+	}
+	cmd.Flags().StringVarP(&device, "device", "d", "", "Specify the name of the device")
+	cmd.Flags().StringVarP(&cmdName, "cmd", "n", "", "Specify the name of the command to be executed")
+	cmd.Flags().StringVarP(&body, "body", "b", "", "Specify PUT requests body/data inline")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "File containing PUT requests body/data")
+	cmd.MarkFlagRequired("device")
+	cmd.MarkFlagRequired("cmdName")
+	return cmd
+}
+
+func handler(cmd *cobra.Command, args []string) (err error) {
+	if (file != "" && body != "") || (file == "" && body == "") {
+		return errors.New("please specify request data using one of the provided ways: --body or --file  ")
+	}
+	if file != "" {
+		content, err := ioutil.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		body = string(content)
+	}
+
+	client := local.New(config.Conf.Clients["Command"].Url() + clients.ApiDeviceRoute)
+	res, err := command.NewCommandClient(client).PutDeviceCommandByNames(context.Background(), device, cmdName, body)
+	if res != "" {
+		fmt.Printf("%s\n", res)
+	}
+	return err
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
https://github.com/edgexfoundry/edgex-cli/issues/253 
https://github.com/edgexfoundry/edgex-cli/issues/254

## What is the new behavior?
Enable executing get/put commands against core-command microservice

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X ] No

## Specific Instructions

Examples: 
./edgex-cli command put -d Random-Float-Device -n Float64 --file ./path/file
./edgex-cli command put -d Random-Float-Device -n Float64 --body '{"filed": "value"}'

./edgex-cli command get -d Random-Float-Device -n Float64

## Other information