### PR TITLE
feat: Add support of Provisioning watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,9 @@ For legacy reasons we support multiple formats in the case of some objects. Goin
 ```
     version       Version command
 ```
+```  
+    watcher       
+      add         Add watcher(s)
+      list        A list of watchers
+      rm          Remove watcher(s) by ID(s)
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/edgexfoundry/edgex-cli/cmd/status"
 	"github.com/edgexfoundry/edgex-cli/cmd/subscription"
 	"github.com/edgexfoundry/edgex-cli/cmd/version"
+	"github.com/edgexfoundry/edgex-cli/cmd/watcher"
 	"github.com/edgexfoundry/edgex-cli/config"
 	"github.com/edgexfoundry/edgex-cli/pkg/pager"
 
@@ -115,6 +116,7 @@ https://www.edgexfoundry.org/
 	cmd.AddCommand(notification.NewCommand())
 	cmd.AddCommand(subscription.NewCommand())
 	cmd.AddCommand(interval.NewCommand())
+	cmd.AddCommand(watcher.NewCommand())
 	cmd.AddCommand(version.NewCommand())
 
 	// global flags

--- a/cmd/watcher/add/add.go
+++ b/cmd/watcher/add/add.go
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright 2020 VMWare.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package add
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+
+	"github.com/edgexfoundry/edgex-cli/config"
+	"github.com/edgexfoundry/edgex-cli/pkg/editor"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/spf13/cobra"
+)
+
+const watcherTemplate = `[{{range $d := .}} 
+{
+  "Name": "{{.Name}}",
+  "AdminState":"{{.AdminState}}",
+  "OperatingState": "{{.OperatingState}}",
+  "Service": {
+     "Name": "{{.Service.Name}}"
+  },
+  "Profile": {
+     "Name": "{{.Profile.Name}}"
+  },
+  "Identifiers":{ {{$s := separator ", "}}{{range $key, $value := .Identifiers}}{{call $s}}
+     "{{$key}}": "{{$value}}"{{end}} 
+  },
+  "BlockingIdentifiers": { {{$s := separator ", "}}{{range $key, $value := .BlockingIdentifiers}}{{call $s}}
+     "{{$key}}": [{{range $k, $v := $value}}"{{$v}}"{{end}}]{{end}} 
+  }
+}
+{{end}}
+]`
+
+var interactiveMode bool
+var name string
+var adminState string
+var profileName string
+var serviceName string
+var numberOfIdentifiers int
+var numberOfBlockingIdentifiers int
+var file string
+
+// NewCommand returns the add watcher command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add watcher(s)",
+		Long:  `Create watchers described in a given JSON file or use the interactive mode with additional flags.`,
+		RunE:  handler,
+	}
+	cmd.Flags().BoolVarP(&interactiveMode, editor.InteractiveModeLabel, "i", false, "Open a default editor to customize the watcher information")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Watcher Name")
+	cmd.Flags().StringVarP(&adminState, "adminState", "a", "", "Admin Status")
+	cmd.Flags().StringVarP(&profileName, "profileName", "p", "", "Device Profile name")
+	cmd.Flags().StringVarP(&serviceName, "serviceName", "s", "", "Device Service name")
+	cmd.Flags().IntVar(&numberOfIdentifiers, "identifiers", 0, "Number of Identifiers")
+	cmd.Flags().IntVarP(&numberOfBlockingIdentifiers, "blockingIdentifiers", "b", 0, "Number of BlockingIdentifiers")
+
+	cmd.Flags().StringVarP(&file, "file", "f", "", "File containing watcher configuration in json format")
+	return cmd
+}
+
+func handler(cmd *cobra.Command, args []string) (err error) {
+	if interactiveMode && file != "" {
+		return errors.New("you could work with interactive mode or file, but not with both")
+	}
+
+	var watchers []models.ProvisionWatcher
+	if file != "" {
+		watchers, err = LoadFromFile(file)
+	} else {
+		watchers, err = parse(interactiveMode)
+
+	}
+
+	if err != nil {
+		return err
+	}
+
+	client := local.New(config.Conf.Clients["Metadata"].Url() + clients.ApiProvisionWatcherRoute)
+	for _, w := range watchers {
+		_, err = metadata.NewProvisionWatcherClient(client).Add(context.Background(), &w)
+		if err != nil {
+			fmt.Println("Error: ", err.Error())
+		}
+	}
+
+	return nil
+}
+
+//LoadFromFile could read a file that contains single ProvisionWatcher or list of ProvisionWatcher
+func LoadFromFile(filePath string) ([]models.ProvisionWatcher, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Error: Invalid Json")
+		}
+	}()
+	file, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var watchers []models.ProvisionWatcher
+
+	//check if the file contains just one ProvisionWatcher
+	var w models.ProvisionWatcher
+	err = json.Unmarshal(file, &w)
+	if err != nil {
+		//check if the file contains list of ProvisionWatcher
+		err = json.Unmarshal(file, &watchers)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		watchers = append(watchers, w)
+	}
+	return watchers, nil
+}
+
+func parse(interactiveMode bool) ([]models.ProvisionWatcher, error) {
+	//parse ProvisionWatcher based on interactive mode and the other provided flags
+	var err error
+	var watchers []models.ProvisionWatcher
+	populate(&watchers)
+	var updatedWatchersBytes []byte
+	if interactiveMode {
+		updatedWatchersBytes, err = editor.OpenInteractiveEditor(watchers, watcherTemplate, template.FuncMap{
+			"separator": separator,
+		})
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedWatchers []models.ProvisionWatcher
+	err = json.Unmarshal(updatedWatchersBytes, &updatedWatchers)
+	if err != nil {
+		return nil, errors.New("Unable to execute the command. The provided information is not valid:" + err.Error())
+	}
+	return updatedWatchers, err
+}
+
+func populate(watchers *[]models.ProvisionWatcher) {
+	w := models.ProvisionWatcher{}
+	w.Name = name
+	w.AdminState = models.AdminState(adminState)
+	w.Profile = models.DeviceProfile{Name: profileName}
+	w.Service = models.DeviceService{Name: serviceName}
+	if numberOfIdentifiers > 0 {
+		identifier := make(map[string]string, numberOfIdentifiers)
+		for i := 0; i < numberOfIdentifiers; i++ {
+			identifier[fmt.Sprintf("Identifier-%d", i)] = "Example Value"
+		}
+		w.Identifiers = identifier
+	}
+	if numberOfBlockingIdentifiers > 0 {
+		bi := make(map[string][]string, numberOfBlockingIdentifiers)
+		for i := 0; i < numberOfBlockingIdentifiers; i++ {
+			bi[fmt.Sprintf("Blocking Identifier-%d", i)] = []string{"Example Value-1"}
+		}
+		w.BlockingIdentifiers = bi
+	}
+	*watchers = append(*watchers, w)
+}
+
+func separator(s string) func() string {
+	i := -1
+	return func() string {
+		i++
+		if i == 0 {
+			return ""
+		}
+		return s
+	}
+}

--- a/cmd/watcher/list/list.go
+++ b/cmd/watcher/list/list.go
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright 2020 VMWare.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package list
+
+import (
+	"context"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/edgexfoundry/edgex-cli/config"
+	"github.com/edgexfoundry/edgex-cli/pkg/formatters"
+
+	"github.com/spf13/cobra"
+)
+
+const template = "ID\tName\tProfile\tService\tAdminState\n" +
+	"{{range .}}" +
+	"{{.Id}}\t{{.Name}}\t{{.Profile.Name}}\t{{.Service.Name}}\t{{.AdminState}}\n" +
+	"{{end}}"
+
+// NewCommand returns the list watcher command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "A list of watchers",
+		Long:  `Return a list of watchers or retrieve a watcher by id`,
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  listHandler,
+	}
+	return cmd
+}
+
+func listHandler(cmd *cobra.Command, args []string) (err error) {
+	client := metadata.NewProvisionWatcherClient(
+		local.New(config.Conf.Clients["Metadata"].Url() + clients.ApiProvisionWatcherRoute),
+	)
+
+	var watchers []models.ProvisionWatcher
+	if len(args) == 0 {
+		watchers, err = client.ProvisionWatchers(context.Background())
+	} else {
+		watchers, err = provisionWatchers(client, args[0])
+	}
+	if err != nil {
+		return err
+	}
+
+	formatter := formatters.NewFormatter(template, nil)
+	err = formatter.Write(watchers)
+	return
+}
+
+func provisionWatchers(client metadata.ProvisionWatcherClient, id string) ([]models.ProvisionWatcher, error) {
+	watcher, err := client.ProvisionWatcher(context.Background(), id)
+	if err != nil {
+		return nil, err
+	}
+	return []models.ProvisionWatcher{watcher}, nil
+}

--- a/cmd/watcher/rm/rm.go
+++ b/cmd/watcher/rm/rm.go
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright 2020 VMWare.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package rm
+
+import (
+	"errors"
+
+	"github.com/edgexfoundry/edgex-cli/config"
+	request "github.com/edgexfoundry/edgex-cli/pkg"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCommand return the rm watcher command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rm [<id> ... ]",
+		Short: "Remove watcher(s) by ID(s)",
+		Long:  `Remove one or more watchers by given ID(s)`,
+		RunE:  removeHandler,
+	}
+	return cmd
+}
+
+func removeHandler(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return errors.New("please provide watcher id(s).\n")
+	}
+
+	client := metadata.NewProvisionWatcherClient(
+		local.New(config.Conf.Clients["Metadata"].Url() + clients.ApiProvisionWatcherRoute),
+	)
+	return request.DeleteByIds(client, args)
+}

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright 2020 VMWare.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package watcher
+
+import (
+	"github.com/edgexfoundry/edgex-cli/cmd/watcher/add"
+	"github.com/edgexfoundry/edgex-cli/cmd/watcher/list"
+	"github.com/edgexfoundry/edgex-cli/cmd/watcher/rm"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns the watcher command of type cobra.Command
+func NewCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "watcher",
+		Short: "Watcher command",
+		Long:  `Actions related to watchers.`,
+	}
+	cmd.AddCommand(list.NewCommand())
+	cmd.AddCommand(rm.NewCommand())
+	cmd.AddCommand(add.NewCommand())
+	return cmd
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
https://github.com/edgexfoundry/edgex-cli/issues/330

## What is the new behavior?
Add ability to list, add, remove Provisioning watchers
./edgex-cli watcher list 
./edgex-cli watcher rm <id> <id2> ..
./edgex-cli watcher add -f /path-to-file
./edgex-cli watcher add -i -n tests --adminState LOCKED --profileName Hilltop-G-GW --serviceName ev-charger --identifiers 2 --blockingIdentifiers 2

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information