### PR TITLE
fix(snap): fix initial configuration file install

### DIFF
--- a/snap/local/runtime-helpers/bin/edgex-cli-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/edgex-cli-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+# configuration.toml is required for the client to run
+if [ ! -f "$HOME/.edgex-cli/configuration.toml" ]; then
+    mkdir -p "$HOME/.edgex-cli"
+    cp "$SNAP/res/sample-configuration.toml" "$HOME/.edgex-cli/configuration.toml"
+    echo "Created $HOME/.edgex-cli/configuration.toml from sample configuration file."
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,8 @@ apps:
   edgex-cli:
     adapter: none
     command: bin/edgex-cli
+    command-chain:
+      - bin/edgex-cli-wrapper.sh
     plugs: [home, network]
 
 parts:
@@ -30,6 +32,10 @@ parts:
       fi
 
       snapcraftctl set-version ${PROJECT_VERSION}
+
+  config-common:
+    plugin: dump
+    source: snap/local/runtime-helpers
 
   go:
     plugin: nil


### PR DESCRIPTION
Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/master/.github/Contributing.md.

## What is the current behavior?
After installing the snap, the first time edgex-cli is run, it will fail due to the client looking for `sample-configuration.toml` via a relative path. I missed this while testing because I built the snap and installed it from the root directory of the git repository, from which the relative path works.

## Issue Number:


## What is the new behavior?
Whenever the client is run via the snap, a wrapper script checks for existence of `configuration.toml`, and it not found, will use the `sample-configuration.toml` to initialize it. The wrapper will also display a message that says the `configuration.toml` file has been initialized and display it's full pathname (`/home/<user>/snap/edge-cli/current/.edgex-cli/configuration.toml`).

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information