### PR TITLE
fix: `make install` creates $home/.edgex-cli/configuration.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ GOFLAGS=-ldflags "-X github.com/edgexfoundry/edgex-cli/cmd/version.Version=$(VER
 ARTIFACT_ROOT?=bin
 
 build:
-	echo "GOPATH=$(GOPATH)"
+	@echo "GOPATH=$(GOPATH)"
 	$(GO) build -o $(BINARY) $(GOFLAGS)
 
 # initial impl. Feel free to override. Please keep ARTIFACT_ROOT coming from env though. CI/CD pipeline relies on this
 build-all:
-	echo "GOPATH=$(GOPATH)"
+	@echo "GOPATH=$(GOPATH)"
 
 	GOOS=linux GOARCH=amd64 $(GO) build -o ${ARTIFACT_ROOT}/$(BINARY)-linux-amd64 $(GOFLAGS)
 	GOOS=linux GOARCH=arm64 $(GO) build -o ${ARTIFACT_ROOT}/$(BINARY)-linux-arm64 $(GOFLAGS)
@@ -47,15 +47,16 @@ test:
 	./bin/test-attribution-txt.sh
 
 install:
-	echo "GOBIN=$(GOBIN)"
+	@echo "GOBIN=$(GOBIN)"
 	$(GO) install $(GOFLAGS)
-	mkdir -p $(GOBIN)/res
-	cp ./res/sample-configuration.toml $(GOBIN)/res
+	mkdir -p $(HOME)/.edgex-cli
+	cp ./res/sample-configuration.toml $(HOME)/.edgex-cli/configuration.toml
+	@echo "Configuration file $(HOME)/.edgex-cli/configuration.toml created"
 
 uninstall:
-	echo "GOBIN=$(GOBIN)"
+	@echo "GOBIN=$(GOBIN)"
 	rm -f $(GOBIN)/$(BINARY)
-	rm -rf $(GOBIN)/$(BINARY)/res $(HOME)/.edgex-cli
+	rm -rf $(HOME)/.edgex-cli
 
 
 clean: uninstall


### PR DESCRIPTION
Signed-off-by: Diana Atanasova <dianaa@vmware.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?
Do not create /res directory in GOBIN. This is a place for
executables only.
add "@" when echo, thus removing double printing the message

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information