### PR TITLE
feat: add V2 support-scheduler

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -48,6 +48,10 @@ func getSelectedServiceKey() string {
 	}
 }
 
+func getSupportSchedulerService() service.Service {
+	return config.GetCoreService(common.SupportSchedulerServiceKey)
+}
+
 func getSupportNotificationsService() service.Service {
 	return config.GetCoreService(common.SupportNotificationsServiceKey)
 }

--- a/internal/cmd/interval.go
+++ b/internal/cmd/interval.go
@@ -1,0 +1,275 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package cmd
+
+import (
+	"context"
+	jsonpkg "encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/spf13/cobra"
+)
+
+var intervalInterval, intervalName, intervalStart, intervalEnd, intervalId string
+
+func init() {
+	var cmd = &cobra.Command{
+		Use:          "interval",
+		Short:        "Add, get and list intervals [Support Scheduler]",
+		Long:         "Add, get and list intervals [Support Scheduler]",
+		SilenceUsage: true,
+	}
+	rootCmd.AddCommand(cmd)
+	initListIntervalCommand(cmd)
+	initGetIntervalByNameCommand(cmd)
+	initAddIntervalCommand(cmd)
+	initRmIntervalCommand(cmd)
+	initUpdateIntervalCommand(cmd)
+}
+
+// initListIntervalCommand implements support for the GET /interval/all endpoint
+// "Given the entire range of intervals sorted by last modified descending,
+// returns a portion of that range according to the offset and limit parameters."
+func initListIntervalCommand(cmd *cobra.Command) {
+	var listCmd = &cobra.Command{
+		Use:          "list",
+		Short:        "List all intervals",
+		Long:         "List all intervals",
+		RunE:         handleListIntervals,
+		SilenceUsage: true,
+	}
+	addFormatFlags(listCmd)
+	addVerboseFlag(listCmd)
+	addLimitOffsetFlags(listCmd)
+	cmd.AddCommand(listCmd)
+}
+
+// initGetIntervalByNameCommand implements support for the GET /interval/name/{name} endpoint
+// "Returns an interval according to the specified name"
+func initGetIntervalByNameCommand(cmd *cobra.Command) {
+	var nameCmd = &cobra.Command{
+		Use:          "name",
+		Short:        "Return an interval by name",
+		Long:         `Return an interval by name`,
+		RunE:         handleGetIntervalByName,
+		SilenceUsage: true,
+	}
+	nameCmd.Flags().StringVarP(&intervalName, "name", "n", "", "Interval name")
+	nameCmd.MarkFlagRequired("name")
+	addFormatFlags(nameCmd)
+	addVerboseFlag(nameCmd)
+	cmd.AddCommand(nameCmd)
+
+}
+
+// initAddIntervalCommand implements support for the POST /interval endpoint
+// "Add one or more new Intervals - name on each request must be unique."
+func initAddIntervalCommand(cmd *cobra.Command) {
+	var add = &cobra.Command{
+		Use:          "add",
+		Short:        "Add an interval",
+		Long:         "Add an interval",
+		Example:      `  edgex-cli interval add -n "hourly" -i "1h"`,
+		RunE:         handleAddInterval,
+		SilenceUsage: true,
+	}
+	add.Flags().StringVarP(&intervalName, "name", "n", "", "Non-database identifier for an interval (*must be unique)")
+	add.Flags().StringVarP(&intervalInterval, "interval", "i", "", "Interval indicates how often the specific resource needs to be polled (e.g. 100ms, 24h)")
+	add.Flags().StringVarP(&intervalStart, "start", "s", "", "Start time in ISO 8601 format YYYYMMDD'T'HHmmss")
+	add.Flags().StringVarP(&intervalEnd, "end", "e", "", "End time in ISO 8601 format YYYYMMDD'T'HHmmss")
+
+	add.MarkFlagRequired("name")
+	add.MarkFlagRequired("interval")
+	cmd.AddCommand(add)
+}
+
+// initRmIntervalCommand implements the DELETE /interval/name/{name}
+// "Deletes an interval according to the specified name. Associated actions will also be deleted."
+func initRmIntervalCommand(cmd *cobra.Command) {
+	var rm = &cobra.Command{
+		Use:          "rm",
+		Short:        "Delete a named interval and associated interval actions",
+		Long:         "Delete a named interval and associated interval actions",
+		RunE:         handleRmInterval,
+		SilenceUsage: true,
+	}
+	rm.Flags().StringVarP(&intervalName, "name", "n", "", "Interval name")
+	rm.MarkFlagRequired("name")
+	cmd.AddCommand(rm)
+}
+
+// initUpdateIntervalCommand implements support for the PATCH /interval endpoint
+// "Update one or more existing Intervals"
+func initUpdateIntervalCommand(cmd *cobra.Command) {
+	var add = &cobra.Command{
+		Use:          "update",
+		Short:        "Update an interval",
+		Long:         "Update an interval, specifying either ID or name ",
+		RunE:         handleUpdateInterval,
+		SilenceUsage: true,
+	}
+	add.Flags().StringVarP(&intervalId, "id", "", "", "Uniquely identifies the interval, either id or name should be specified.")
+	add.Flags().StringVarP(&intervalName, "name", "n", "", "Non-database identifier for an interval (*must be unique), either id or name should be specified")
+	add.Flags().StringVarP(&intervalInterval, "interval", "i", "", "Interval indicates how often the specific resource needs to be polled (e.g. 100ms, 24h)")
+	add.Flags().StringVarP(&intervalStart, "start", "s", "", "Start time in ISO 8601 format YYYYMMDD'T'HHmmss")
+	add.Flags().StringVarP(&intervalEnd, "end", "e", "", "End time in ISO 8601 format YYYYMMDD'T'HHmmss")
+
+	cmd.AddCommand(add)
+}
+
+func handleUpdateInterval(cmd *cobra.Command, args []string) error {
+	var name, id, start, end, interval *string
+
+	client := getSupportSchedulerService().GetIntervalClient()
+	if intervalName != "" {
+		name = &intervalName
+	}
+	if intervalId != "" {
+		id = &intervalId
+	}
+	if name == nil && id == nil {
+		return errors.New("either id or name should be specified")
+	}
+	if intervalStart != "" {
+		start = &intervalStart
+	}
+	if intervalEnd != "" {
+		end = &intervalEnd
+	}
+	if intervalInterval != "" {
+		interval = &intervalInterval
+	}
+	var req = requests.NewUpdateIntervalRequest(dtos.UpdateInterval{
+		Name:     name,
+		Id:       id,
+		Start:    start,
+		End:      end,
+		Interval: interval})
+	response, err := client.Update(context.Background(), []requests.UpdateIntervalRequest{req})
+	if response != nil {
+		fmt.Println(response[0])
+	}
+	return err
+}
+
+func handleRmInterval(cmd *cobra.Command, args []string) error {
+	client := getSupportSchedulerService().GetIntervalClient()
+	response, err := client.DeleteIntervalByName(context.Background(), intervalName)
+	if err == nil {
+		fmt.Println(response.Message)
+	}
+	return err
+}
+
+func handleAddInterval(cmd *cobra.Command, args []string) error {
+	client := getSupportSchedulerService().GetIntervalClient()
+	var req = requests.NewAddIntervalRequest(dtos.Interval{
+		Name:     intervalName,
+		Interval: intervalInterval,
+		Start:    intervalStart,
+		End:      intervalEnd})
+	response, err := client.Add(context.Background(), []requests.AddIntervalRequest{req})
+	if err != nil {
+		return err
+	}
+	if response != nil {
+		fmt.Println(response[0])
+	}
+	return err
+}
+
+func handleGetIntervalByName(cmd *cobra.Command, args []string) error {
+	client := getSupportSchedulerService().GetIntervalClient()
+	response, err := client.IntervalByName(context.Background(), intervalName)
+	if err != nil {
+		return err
+	}
+	if json {
+		result, err := jsonpkg.Marshal(response)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(result))
+	} else {
+		w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
+		printIntervalTableHeader(w)
+		printInterval(w, &response.Interval)
+		w.Flush()
+	}
+	return nil
+}
+
+func handleListIntervals(cmd *cobra.Command, args []string) error {
+	client := getSupportSchedulerService().GetIntervalClient()
+	response, err := client.AllIntervals(context.Background(), offset, limit)
+	if err != nil {
+		return err
+	}
+
+	if json {
+		result, err := jsonpkg.Marshal(response)
+		if err != nil {
+			return err
+		}
+		fmt.Print(string(result))
+	} else {
+
+		if len(response.Intervals) == 0 {
+			fmt.Println("No intervals available")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
+		printIntervalTableHeader(w)
+		for _, n := range response.Intervals {
+			printInterval(w, &n)
+		}
+		w.Flush()
+	}
+	return nil
+}
+
+func printIntervalTableHeader(w *tabwriter.Writer) {
+	if verbose {
+		fmt.Fprintln(w, "Id\tName\tInterval\tStart\tEnd")
+	} else {
+		fmt.Fprintln(w, "Name\tInterval\tStart\tEnd")
+	}
+
+}
+
+func printInterval(w *tabwriter.Writer, n *dtos.Interval) {
+	if verbose {
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
+			n.Id,
+			n.Name,
+			n.Interval,
+			n.Start,
+			n.End)
+	} else {
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n",
+			n.Name,
+			n.Interval,
+			n.Start,
+			n.End)
+	}
+}

--- a/internal/cmd/intervalaction.go
+++ b/internal/cmd/intervalaction.go
@@ -1,0 +1,326 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package cmd
+
+import (
+	"context"
+	jsonpkg "encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/spf13/cobra"
+)
+
+var intervalActionName, intervalActionIntervalName, intervalActionAddress, intervalActionId string
+var intervalActionContent, intervalActionContentType, intervalActionAdminState string
+
+func init() {
+	var cmd = &cobra.Command{
+		Use:          "intervalaction",
+		Short:        "Get, list, update and remove interval actions [Support Scheduler]",
+		Long:         "Get, list, update and remove interval actions [Support Scheduler]",
+		SilenceUsage: true,
+	}
+	rootCmd.AddCommand(cmd)
+	initAddIntervalActionCommand(cmd)
+	initListIntervalActionCommand(cmd)
+	initGetIntervalActionByNameCommand(cmd)
+	initRmIntervalActionCommand(cmd)
+	initUpdateIntervalActionCommand(cmd)
+}
+
+// initListIntervalActionCommand implements support for the GET /intervalaction/all endpoint
+// "Given the entire range of interval actions sorted by last modified descending,
+// returns a portion of that range according to the offset and limit parameters."
+func initListIntervalActionCommand(cmd *cobra.Command) {
+	var listCmd = &cobra.Command{
+		Use:          "list",
+		Short:        "List all interval actions",
+		Long:         "List all interval actions",
+		RunE:         handleListIntervalActions,
+		SilenceUsage: true,
+	}
+	addFormatFlags(listCmd)
+	addVerboseFlag(listCmd)
+	addLimitOffsetFlags(listCmd)
+	cmd.AddCommand(listCmd)
+}
+
+// initGetIntervalActionByNameCommand implements support for the GET /intervalaction/name/{name} endpoint
+// "Returns an interval action according to the specified name"
+func initGetIntervalActionByNameCommand(cmd *cobra.Command) {
+	var nameCmd = &cobra.Command{
+		Use:          "name",
+		Short:        "Return an interval action by name",
+		Long:         `Return an interval action by name`,
+		RunE:         handleGetIntervalActionByName,
+		SilenceUsage: true,
+	}
+	nameCmd.Flags().StringVarP(&intervalActionName, "name", "n", "", "Interval action name")
+	nameCmd.MarkFlagRequired("name")
+	addFormatFlags(nameCmd)
+	addVerboseFlag(nameCmd)
+	cmd.AddCommand(nameCmd)
+
+}
+
+// initAddIntervalActionCommand implements the POST /intervalaction endpoint
+// "Adds one or more notifications to be sent."
+func initAddIntervalActionCommand(cmd *cobra.Command) {
+	var add = &cobra.Command{
+		Use:          "add",
+		Short:        "Add an interval action",
+		Long:         "Add an interval action",
+		Example:      `  edgex-cli intervalaction add -n "name01" -i "midnight" -a "{\"type\": \"REST\", \"host\": \"192.168.0.102\", \"port\": 8080, \"httpMethod\": \"GET\"}"`,
+		RunE:         handleAddIntervalAction,
+		SilenceUsage: true,
+	}
+
+	add.Flags().StringVarP(&intervalActionName, "name", "n", "", "Interval action name")
+	add.Flags().StringVarP(&intervalActionIntervalName, "interval", "i", "", "Name of the interval associated with this action")
+	add.Flags().StringVarP(&intervalActionAddress, "address", "a", "", "JSON representation of the address information")
+	add.Flags().StringVarP(&intervalActionContent, "content", "c", "", "Interval action content")
+	add.Flags().StringVarP(&intervalActionContentType, "content-type", "t", "", "Interval action content type  (i.e. text/html, application/json)")
+	add.Flags().StringVarP(&intervalActionAdminState, "admin-state", "", "UNLOCKED", "Admin state [LOCKED | UNLOCKED]")
+
+	addLabelsFlag(add)
+	add.MarkFlagRequired("name")
+	add.MarkFlagRequired("interval")
+	add.MarkFlagRequired("address")
+	cmd.AddCommand(add)
+}
+
+// initRmIntervalActionCommand implements the DELETE /intervalaction/name/{name}
+// "Deletes an interval action by name"
+func initRmIntervalActionCommand(cmd *cobra.Command) {
+	var rm = &cobra.Command{
+		Use:          "rm",
+		Short:        "Delete an interval action by name",
+		Long:         "Delete an interval action by name",
+		RunE:         handleRmIntervalAction,
+		SilenceUsage: true,
+	}
+	rm.Flags().StringVarP(&intervalActionName, "name", "n", "", "Interval action name")
+	rm.MarkFlagRequired("name")
+	cmd.AddCommand(rm)
+}
+
+// initUpdateIntervalActionCommand implements support for the PATCH /intervalaction endpoint
+// "Update one or more existing IntervalActions"
+func initUpdateIntervalActionCommand(cmd *cobra.Command) {
+	var add = &cobra.Command{
+		Use:          "update",
+		Short:        "Update an interval action",
+		Long:         "Update an interval action, specifying either ID or name ",
+		RunE:         handleUpdateIntervalAction,
+		SilenceUsage: true,
+	}
+	add.Flags().StringVarP(&intervalActionId, "id", "", "", "Uniquely identifies the interval action, either id or name should be specified.")
+	add.Flags().StringVarP(&intervalActionName, "name", "n", "", "Interval action name")
+	add.Flags().StringVarP(&intervalActionIntervalName, "interval", "i", "", "Name of the interval associated with this action")
+	add.Flags().StringVarP(&intervalActionAddress, "address", "a", "", "JSON representation of the address information")
+	add.Flags().StringVarP(&intervalActionContent, "content", "c", "", "Interval action content")
+	add.Flags().StringVarP(&intervalActionContentType, "content-type", "t", "", "Interval action content type  (i.e. text/html, application/json)")
+	add.Flags().StringVarP(&intervalActionAdminState, "admin-state", "", "UNLOCKED", "Admin state [LOCKED | UNLOCKED]")
+
+	cmd.AddCommand(add)
+}
+
+func handleUpdateIntervalAction(cmd *cobra.Command, args []string) error {
+	client := getSupportSchedulerService().GetIntervalActionClient()
+
+	var name, id, intervalName, content, contentType, adminState *string
+	var address *dtos.Address
+
+	if intervalActionId != "" {
+		id = &intervalActionId
+	}
+	if intervalActionName != "" {
+		name = &intervalActionName
+	}
+	if name == nil && id == nil {
+		return errors.New("either id or name should be specified")
+	}
+	if intervalActionIntervalName != "" {
+		intervalName = &intervalActionIntervalName
+	}
+	if intervalActionAddress != "" {
+		address = new(dtos.Address)
+		err := jsonpkg.Unmarshal([]byte(intervalActionAddress), address)
+		if err != nil {
+			err = fmt.Errorf("channels JSON object array invalid (%v)", err)
+		}
+		return err
+	}
+	if intervalActionContent != "" {
+		content = &intervalActionContent
+	}
+	if intervalActionContentType != "" {
+		contentType = &intervalActionContentType
+	}
+	if intervalActionAdminState != "" {
+		err := validateAdminState(intervalActionAdminState)
+		if err != nil {
+			return err
+		}
+		adminState = &intervalActionAdminState
+	}
+
+	var req = requests.NewUpdateIntervalActionRequest(dtos.UpdateIntervalAction{
+		Name:         name,
+		Id:           id,
+		IntervalName: intervalName,
+		Content:      content,
+		ContentType:  contentType,
+		Address:      address,
+		AdminState:   adminState})
+
+	response, err := client.Update(context.Background(), []requests.UpdateIntervalActionRequest{req})
+	if response != nil {
+		fmt.Println(response[0])
+	}
+	return err
+
+}
+
+func handleAddIntervalAction(cmd *cobra.Command, args []string) error {
+	var address dtos.Address
+
+	client := getSupportSchedulerService().GetIntervalActionClient()
+	err := validateAdminState(intervalActionAdminState)
+	if err != nil {
+		return err
+	}
+	if intervalActionAddress != "" {
+		err = jsonpkg.Unmarshal([]byte(intervalActionAddress), &address)
+		if err != nil {
+			err = fmt.Errorf("channels JSON object array invalid (%v)", err)
+			return err
+		}
+	}
+
+	var req = requests.NewAddIntervalActionRequest(dtos.IntervalAction{
+		Name:         intervalActionName,
+		IntervalName: intervalActionIntervalName,
+		Address:      address,
+		Content:      intervalActionContent,
+		ContentType:  intervalActionContentType,
+
+		AdminState: intervalActionAdminState})
+	response, err := client.Add(context.Background(), []requests.AddIntervalActionRequest{req})
+
+	if err == nil && response != nil {
+		fmt.Println(response[0])
+	}
+
+	return err
+}
+
+func handleRmIntervalAction(cmd *cobra.Command, args []string) error {
+	client := getSupportSchedulerService().GetIntervalActionClient()
+
+	response, err := client.DeleteIntervalActionByName(context.Background(), intervalActionName)
+	if err == nil {
+		fmt.Println(response.Message)
+	}
+	return err
+}
+
+func handleGetIntervalActionByName(cmd *cobra.Command, args []string) error {
+	client := getSupportSchedulerService().GetIntervalActionClient()
+	response, err := client.IntervalActionByName(context.Background(), intervalActionName)
+	if err != nil {
+		return err
+	}
+	if json {
+		result, err := jsonpkg.Marshal(response)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(result))
+	} else {
+		w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
+		printIntervalActionTableHeader(w)
+		printIntervalAction(w, &response.Action)
+		w.Flush()
+	}
+	return nil
+}
+
+func handleListIntervalActions(cmd *cobra.Command, args []string) error {
+	client := getSupportSchedulerService().GetIntervalActionClient()
+	response, err := client.AllIntervalActions(context.Background(), offset, limit)
+	if err != nil {
+		return err
+	}
+
+	if json {
+		result, err := jsonpkg.Marshal(response)
+		if err != nil {
+			return err
+		}
+		fmt.Print(string(result))
+	} else {
+
+		if len(response.Actions) == 0 {
+			fmt.Println("No interval actions available")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
+		printIntervalActionTableHeader(w)
+		for _, n := range response.Actions {
+			printIntervalAction(w, &n)
+		}
+		w.Flush()
+	}
+	return nil
+}
+
+func printIntervalActionTableHeader(w *tabwriter.Writer) {
+	if verbose {
+		fmt.Fprintln(w, "Id\tName\tInterval\tAddress\tContent\tContentType\tAdminState\tCreated\tUpdated")
+	} else {
+		fmt.Fprintln(w, "Name\tInterval\tAddress\tContent\tContentType")
+	}
+}
+
+func printIntervalAction(w *tabwriter.Writer, n *dtos.IntervalAction) {
+	if verbose {
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+			n.Id,
+			n.Name,
+			n.IntervalName,
+			n.Address,
+			n.Content,
+			n.ContentType,
+			n.AdminState,
+			getRFC822Time(n.Created),
+			getRFC822Time(n.Modified))
+	} else {
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
+			n.Name,
+			n.IntervalName,
+			n.Address,
+			n.Content,
+			n.ContentType)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -86,3 +86,13 @@ func (c Service) GetTransmissionClient() interfaces.TransmissionClient {
 	url := fmt.Sprintf("http://%s:%v", c.Host, c.Port)
 	return http.NewTransmissionClient(url)
 }
+
+func (c Service) GetIntervalClient() interfaces.IntervalClient {
+	url := fmt.Sprintf("http://%s:%v", c.Host, c.Port)
+	return http.NewIntervalClient(url)
+}
+
+func (c Service) GetIntervalActionClient() interfaces.IntervalActionClient {
+	url := fmt.Sprintf("http://%s:%v", c.Host, c.Port)
+	return http.NewIntervalActionClient(url)
+}


### PR DESCRIPTION
This commit adds support for support-scheduler endpoints:

- interval [add,name,list,rm,update]
- intervalaction [add,name,list,rm,update]

Fix #388

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-cli/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) WIll be added in separate PR
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) Will be added in a separate PR
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

1. Install EdgeXFoundry and start up support-scheduler service
2. Build the CLI from this PR with `make build` and test the commands as follows:

### interval [add/list/name/rm/update]

```
# print help
./bin/edgex-cli interval

# add interval
./bin/edgex-cli interval add -h
./bin/edgex-cli interval add -n "hourly" -i "1h"

# get the new interval
./bin/edgex-cli interval name -h
./bin/edgex-cli interval name -n "hourly"
./bin/edgex-cli interval name -n "hourly" -v
./bin/edgex-cli interval name -n "hourly" -j | jq '.'

# list all intervals
./bin/edgex-cli interval list -h
./bin/edgex-cli interval list
./bin/edgex-cli interval list -v
./bin/edgex-cli interval list  -j | jq '.'

# update interval
./bin/edgex-cli interval update -h
./bin/edgex-cli interval update -n "hourly" -i "1m"
./bin/edgex-cli interval name -n "hourly" -v

# remove interval
./bin/edgex-cli interval rm -h
./bin/edgex-cli interval rm  -n "hourly" 
./bin/edgex-cli interval name -n "hourly" 
./bin/edgex-cli interval list
```

### interval action [add/list/name/rm/update]

```
# print help
./bin/edgex-cli intervalaction

# add interval action
./bin/edgex-cli intervalaction add -h
./bin/edgex-cli interval add -n "hourly" -i "1h"
./bin/edgex-cli intervalaction add -n "name01" -i "midnight" -a "{\"type\": \"REST\", \"host\": \"192.168.0.102\", \"port\": 8080, \"httpMethod\": \"GET\"}"

# get the new interval action
./bin/edgex-cli intervalaction name -h
./bin/edgex-cli intervalaction name -n "name01"
./bin/edgex-cli intervalaction name -n "name01" -v
./bin/edgex-cli intervalaction name -n "name01" -j | jq '.'

# list all interval actions
./bin/edgex-cli intervalaction list -h
./bin/edgex-cli intervalaction list
./bin/edgex-cli intervalaction list -v
./bin/edgex-cli intervalaction list  -j | jq '.'

# update interval action
./bin/edgex-cli intervalaction update -h
./bin/edgex-cli intervalaction update -n "name01" --admin-state "LOCKED"
./bin/edgex-cli intervalaction name -n "name01" -v

# remove interval action
./bin/edgex-cli intervalaction rm -h
./bin/edgex-cli intervalaction rm  -n "name01" 
./bin/edgex-cli intervalaction name -n "name01" 
./bin/edgex-cli intervalaction list
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->