### PR TITLE
build(snap): source metadata from central repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ archives
 bin
 VERSION
 go
+
+# snap files
+*.snap
+*.assert
+prime/
+stage/
+parts/
+squashfs-root/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,7 @@
 name: edgex-cli
 base: core20
 type: app
-adopt-info: version
-summary: A command-line client for EdgeX Foundry
-description: |
-  A command-line client for EdgeX Foundry.
+adopt-info: metadata
 
 grade: stable
 confinement: strict
@@ -18,36 +15,48 @@ apps:
     plugs: [home, network]
 
 parts:
-  version:
-    plugin: nil
-    # we need to include git, in case we are building the minimal-snap-build
-    build-packages:
-      - git
-    # as with static-packages part, the source dir is unrelated to this part and is used
-    # since it changes rarely and therefore will not trigger a new pull
-    source: snap/local/runtime-helpers
-    override-pull: |
-      cd $SNAPCRAFT_PROJECT_DIR
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      snapcraftctl set-version ${GIT_VERSION}
-
   config-common:
     plugin: dump
     source: snap/local/runtime-helpers
 
   edgex-cli:
+    after: [metadata]
     source: .
     plugin: make 
     build-snaps:
       - go/1.17/stable 
     override-build: |
       cd $SNAPCRAFT_PART_SRC
+
+      # the version is needed for the build
+      cat ./VERSION
+
       make tidy
       make build
       install -DT "./bin/edgex-cli" "$SNAPCRAFT_PART_INSTALL/bin/edgex-cli"
       install -DT "./Attribution.txt" "$SNAPCRAFT_PART_INSTALL/usr/share/doc/edgex-cli/Attribution.txt"
       install -DT "./LICENSE" "$SNAPCRAFT_PART_INSTALL/usr/share/doc/edgex-cli/LICENSE" 
+
+  metadata:
+    plugin: nil
+    source: https://github.com/canonical/edgex-snap-metadata.git
+    source-branch: appstream
+    source-depth: 1
+    override-build: |
+      # install the icon at the default internal path
+      install -DT edgex-snap-icon.png \
+        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
+      # change to this project's repo to get the version
+      cd $SNAPCRAFT_PROJECT_DIR
+      if git describe ; then
+        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      else
+        VERSION="0.0.0"
+      fi
+      
+      # write version to file for the build
+      echo $VERSION > ./VERSION
+      # set the version of this snap
+      snapcraftctl set-version $VERSION
+    parse-info: [edgex-cli.metainfo.xml] 
 


### PR DESCRIPTION
The metadata kept in snapcraft.yaml is obsolete because it is being overridden on the store. This change will allow sourcing the central copy of metadata.

See https://github.com/canonical/edgex-snap-metadata/issues/2

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-cli/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
# clean and build:
$ snapcraft clean && snapcraft

# unpack the built snap:
$ unsquashfs name.snap

# verify that icon exists:
$ ls squashfs-root/meta/gui/icon.png 
squashfs-root/meta/gui/icon.png

# verify that version, summary and description are included
$ cat squashfs-root/meta/snap.yaml
name: edgex-cli
version: 2.0.0-dev.20
summary: EdgeX CLI
description: |-
  EdgeX CLI is a command-line interface tool for developers, used for interacting with the EdgeX microservices.

  For a graphical user interface, see https://snapcraft.io/edgex-ui

  **Snap usage instructions**

  https://github.com/edgexfoundry/edgex-cli/blob/main/snap/README.md

  **Source code and more info**

  https://github.com/edgexfoundry/edgex-cli

  **Getting started**

  * v1.3: https://docs.edgexfoundry.org/1.3/getting-started/tools/Ch-CommandLineInterface
  * v2.1: https://docs.edgexfoundry.org/2.1/getting-started/tools/Ch-CommandLineInterface
  * v2.2: https://docs.edgexfoundry.org/2.2/getting-started/tools/Ch-CommandLineInterface

  **EdgeX Documentation**

  https://docs.edgexfoundry.org

  **Reference platform snap**

  https://snapcraft.io/edgexfoundry

...
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->