### PR TITLE
test(snap): add CI workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -25,8 +25,10 @@ jobs:
     steps:
       - name: Download and test snap
         # uses: canonical/edgex-snap-testing/test@v2
-        uses: MonicaisHer/edgex-snap-testing/build@EDGEX-416-create-edgex-cli-testing-suite
+        uses: MonicaisHer/edgex-snap-testing/test@EDGEX-416-create-edgex-cli-testing-suite
         with:
           name: cli
           snap: ${{needs.build.outputs.snap}}
+          print_logs: false
+          
 

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -14,8 +14,7 @@ jobs:
     steps:
       - name: Build and upload snap
         id: build
-        # uses: canonical/edgex-snap-testing/build@v2
-        uses: MonicaisHer/edgex-snap-testing/build@EDGEX-416-create-edgex-cli-testing-suite
+        uses: canonical/edgex-snap-testing/build@v2
     outputs:
       snap: ${{steps.build.outputs.snap}}
 
@@ -24,8 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download and test snap
-        # uses: canonical/edgex-snap-testing/test@v2
-        uses: MonicaisHer/edgex-snap-testing/test@EDGEX-416-create-edgex-cli-testing-suite
+        uses: canonical/edgex-snap-testing/test@v2
         with:
           name: cli
           snap: ${{needs.build.outputs.snap}}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,32 @@
+name: Snap Testing
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and upload snap
+        id: build
+        # uses: canonical/edgex-snap-testing/build@v2
+        uses: MonicaisHer/edgex-snap-testing/build@EDGEX-416-create-edgex-cli-testing-suite
+    outputs:
+      snap: ${{steps.build.outputs.snap}}
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download and test snap
+        # uses: canonical/edgex-snap-testing/test@v2
+        uses: MonicaisHer/edgex-snap-testing/build@EDGEX-416-create-edgex-cli-testing-suite
+        with:
+          name: cli
+          snap: ${{needs.build.outputs.snap}}
+


### PR DESCRIPTION
The workflow added here will activate only after it has been merged into the main. In the meantime, https://github.com/MonicaisHer/edgex-cli/pull/1 that is against the fork can be taken as a reference.

Signed-off-by: Mengyi Wang [mengyi.wang@canonical.com](mailto:mengyi.wang@canonical.com)

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-cli/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-cli/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) https://github.com/MonicaisHer/edgex-cli/pull/1
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->