### PR TITLE
docs(snap): Move usage instructions to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ See the [CLI Getting started documentation](https://docs.edgexfoundry.org/2.2/ge
 
 ## Installing EdgeX CLI
 
-The client can be installed using a [snap](https://github.com/edgexfoundry/edgex-cli/tree/main/snap):
-
-```
+The client can be installed using a Snap:
+```bash
 sudo snap install edgex-cli
 ```
+Please refer to the [snap directory](./snap) for details.
 
 To build, install and run `edgex-cli` natively, do the following:
-```
+```bash
 git clone http://github.com/edgexfoundry/edgex-cli.git
 cd edgex-cli
 make tidy
@@ -26,7 +26,7 @@ make build
 ```
 
 ## Limitations
-- The client requires all services to run on the local host. It does not support a distributed configuration or using the API gateway ([#427](https://github.com/edgexfoundry/edgex-cli/issues/427))
+- The client requires all services to run on the localhost. It does not support a distributed configuration or using the API gateway ([#427](https://github.com/edgexfoundry/edgex-cli/issues/427))
 - The `db` command from the v1 client is not supported ([#383](https://github.com/edgexfoundry/edgex-cli/issues/383))
 - See this list of [all current enhancement issues](https://github.com/edgexfoundry/edgex-cli/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) 
 

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,47 +1,24 @@
 # EdgeX CLI Snap
-[![snap store badge](https://raw.githubusercontent.com/snapcore/snap-store-badges/master/EN/%5BEN%5D-snap-store-black-uneditable.png)](https://snapcraft.io/edgex-cli)
+[![edgex-cli](https://snapcraft.io/edgex-cli/badge.svg)][edgex-cli]
 
-This folder contains snap packaging for the EdgeX-CLI Snap
+This directory contains the snap packaging of the EdgeX CLI.
 
-The snap currently supports both `amd64` and `arm64` platforms.
+The snap is built automatically and published on the Snap Store as [edgex-cli].
 
-## Installation
+For usage instructions, please refer to EdgeX CLI section in [Getting Started using Snaps][docs].
 
-### Installing snapd
-The snap can be installed on any system that supports snaps. You can see how to install 
-snaps on your system [here](https://snapcraft.io/docs/installing-snapd/6735).
-
-However for full security confinement, the snap should be installed on an 
-Ubuntu 18.04 LTS or later (Desktop or Server), or a system running Ubuntu Core 18 or later.
-
-### Installing EdgeX CLI as a snap
-The snap is published in the snap store at https://snapcraft.io/edgex-cli.
-You can see the current revisions available for your machine's architecture by running the command:
-
-```bash
-$ snap info edgex-cli
+## Build from source
+Execute the following command from the top-level directory of this repo:
+```
+snapcraft
 ```
 
-The latest stable version of the snap can be installed using:
-
+This will create a snap package file with `.snap` extension. It can be installed locally by setting the `--dangerous` flag:
 ```bash
-$ sudo snap install edgex-cli
+sudo snap install --dangerous <snap-file>
 ```
 
-The latest development version of the snap can be installed using:
+The [snapcraft overview](https://snapcraft.io/docs/snapcraft-overview) provides additional details.
 
-```bash
-$ sudo snap install edgex-cli --edge
-```
-
-A specific version of the snap can be installed by setting the channel, for instance for 2.1 (Jakarta):
-
-```bash
-$ sudo snap install edgex-cli --channel=2.1
-```
-
-For the older CLI version compatible with 1.x of EdgeX, use `--channel=1.0`
-
-
-
-**Note** - the snap has only been tested on Ubuntu Core, Desktop, and Server.
+[edgex-cli]: https://snapcraft.io/edgex-cli
+[docs]: https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#edgex-cli


### PR DESCRIPTION
Usage instructions are being moved to docs; see https://github.com/edgexfoundry/edgex-docs/pull/751.
The snap/README has been updated to include development docs only.

Depends on:
- https://github.com/edgexfoundry/edgex-docs/pull/751

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->